### PR TITLE
Drop the HQ from the Cachet name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# CachetHQ Status
+# Cachet Status
 
-> CachetHQ - an open source status page system, for everyone.  
+> Cachet - an open source status page system, for everyone.
 > -- [cachethq.io](https://cachethq.io/)
 
-`CachetStatus` uses CachetHQ API to get a list of system components and their
+`CachetStatus` uses Cachet API to get a list of system components and their
 statuses.
 
 You decide what to do with received information. On the demo page you could
@@ -15,8 +15,8 @@ find an example of a nice looking popover window with all GoHiring APIs and thei
 
 `CachetStatus` constructor received two parameters:
 
-  - CachetHQ site base URL,
-  - callback function that will be called when a response from CachetHQ API got received.
+  - Cachet site base URL.
+  - callback function that will be called when a response from Cachet API got received.
 
 The callback function gets an array of objects where each object represents one system component and its status.
 
@@ -28,11 +28,11 @@ var callback = function (components) {
 };
 
 new CachetStatus('https://status.gohiring.com', callback);
-```  
+```
 
 ## Credits
 
-[CachetHQ](https://cachethq.io/) is awesome! You should try it when you need a status page.
+[Cachet](https://cachethq.io/) is awesome! You should try it when you need a status page.
 
 ## Copyright information
 


### PR DESCRIPTION
Thanks for this, it's awesome!

Looking forward to sharing this on our `@cachethq` account, but we need to fix the names first :)
